### PR TITLE
Bug fix when video is played when progress is zero

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -76,7 +76,7 @@ io.on("connection", (socket) => {
     const responseData = {
       videoUrl: currentSession.videoUrl,
       progress: lastEvent?.progress ?? 0,
-      isPlaying: lastEvent?.type === "PLAY" ?? false,
+      isPlaying: lastEvent ? lastEvent.type === "PLAY" : false,
     };
     console.log(`Sending session state to user ${socket.id}:`, responseData);
     callback(responseData);

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -35,7 +35,12 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
   console.log("VideoPlayer: ", url);
 
   useEffect(() => {
-    if (playingVideo && !!url && !!player.current?.getInternalPlayer() && !hasJoined) {
+    if (
+      playingVideo &&
+      !!url &&
+      !!player.current?.getInternalPlayer() &&
+      !hasJoined
+    ) {
       handleWatchStart();
     }
   }, [played, playingVideo, url, player.current?.getInternalPlayer()]); // Triggers when user is joining late and video is already playing. Waits for player to initialize, otherwise plays on a black screen.
@@ -67,13 +72,16 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
     socket.emit("joinSession", sessionId, (response: JoinSessionResponse) => {
       setHasJoined(true);
       console.log("Received join session response: ", response);
+
       if (response.progress > 0) {
         seekToVideo(response.progress);
-        if (response.isPlaying) {
-          playVideo();
-        }
-        setPlayed(response.progress);
-        setPlayingVideo(response.isPlaying);
+      }
+      setPlayed(response.progress);
+      setPlayingVideo(response.isPlaying);
+
+      // Start playing if the session is currently playing
+      if (response.isPlaying) {
+        playVideo();
       }
     });
   };

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -79,7 +79,6 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
       setPlayed(response.progress);
       setPlayingVideo(response.isPlaying);
 
-      // Start playing if the session is currently playing
       if (response.isPlaying) {
         playVideo();
       }


### PR DESCRIPTION
Fixes a bug when second client joins and last action was first client clicks play at progress zero; sometimes detracts from finding the actual bug we care about 